### PR TITLE
Fix removing to much when creating a dotted attribute key

### DIFF
--- a/src/JSON.php
+++ b/src/JSON.php
@@ -270,7 +270,7 @@ class JSON extends MergeValue
      */
     protected function getDottedAttributeKey(string $attribute): string
     {
-        return str_replace(["{$this->attribute}->", '->'], ['', '.'], $attribute);
+        return \str_replace('->', '.', Str::after($attribute, "{$this->attribute}->"));
     }
 
     /**


### PR DESCRIPTION
When having a JSON structure with nested data with a key ending (or being the same as the parent property to much is removed from the attribute when it is converted into a dotted key.

 Example:
```json
{
  "settings": {
    "personal_settings": {
      "darkmode": true
    }
}
```

Without this fix a call to `getDottedAttributeKey` will give the attribute `personal_darkmode` instead of the expected `personal_settings.darkmode`.